### PR TITLE
Split and clean up `DeviceSettingsPanel`

### DIFF
--- a/client/src/adminPage.tsx
+++ b/client/src/adminPage.tsx
@@ -86,8 +86,11 @@ export const AdminPage = () => {
             {
               loadableAdminData.data.deviceViews[selectedDeviceIndex] ?
                 <DeviceSettingsPanel
-                  adminDeviceView={
-                    loadableAdminData.data.deviceViews[selectedDeviceIndex]
+                  device={
+                    loadableAdminData
+                      .data
+                      .deviceViews[selectedDeviceIndex]
+                      .device
                   }
                 />
                 :

--- a/client/src/adminPage/deviceSettingsPanel/editableDeviceDisplayName.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/editableDeviceDisplayName.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import {useEffect, useState} from 'react';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import {Device} from '../../../../proto_out/lightning_vend/model';
+import {DeviceName} from '../../../../shared/proto';
+import EditIcon from '@mui/icons-material/Edit';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import Typography from '@mui/material/Typography';
+import {adminApi} from '../../api/adminApi';
+
+interface EditableDeviceDisplayNameProps {
+  device: Device
+}
+
+export const EditableDeviceDisplayName = (
+  props: EditableDeviceDisplayNameProps
+) => {
+  const [isEditingDisplayName, setIsEditingDisplayName] = useState(false);
+  const [newDisplayName, setNewDisplayName] = useState('');
+
+  useEffect(() => {
+    setNewDisplayName(props.device.displayName || '');
+  }, [isEditingDisplayName]);
+
+  const updateDisplayName = () => {
+    const deviceName = DeviceName.parse(props.device.name);
+    // TODO - Indicate to the user if `deviceName` is undefined.
+    if (deviceName) {
+      adminApi
+        .updateDeviceDisplayName(deviceName, newDisplayName)
+        .then(() => setIsEditingDisplayName(false));
+    }
+  };
+
+  return isEditingDisplayName ? (
+    <OutlinedInput
+      // These styles are to match the Typography h2 below.
+      style={{
+        fontWeight: 300,
+        fontSize: '3.75em',
+        lineHeight: 1.2,
+        letterSpacing: '-0.00833em',
+        width: '100%'
+      }}
+      autoFocus
+      value={newDisplayName}
+      onChange={(e) => setNewDisplayName(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          updateDisplayName();
+        }
+      }}
+      endAdornment={
+        <InputAdornment position={'end'}>
+          <IconButton
+            size={'large'}
+            color={'primary'}
+            onClick={() => updateDisplayName()}
+          >
+            <CheckCircleIcon/>
+          </IconButton>
+        </InputAdornment>
+      }
+    />
+  ) : (
+    <div style={{display: 'flex'}}>
+      <Typography
+        variant={'h2'}
+        style={{
+          padding: '23.5px 14px 23.75px',
+          width: '100%',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis'
+        }}
+      >
+        {props.device.displayName}
+      </Typography>
+      <IconButton
+        size={'large'}
+        style={{marginTop: '35px', marginRight: '14px', height: '100%'}}
+        onClick={() => setIsEditingDisplayName(!isEditingDisplayName)}
+      >
+        <EditIcon/>
+      </IconButton>
+    </div>
+  );
+};

--- a/client/src/adminPage/deviceSettingsPanel/index.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/index.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {AdminDeviceView} from '../../../../shared/adminSocketTypes';
 import Button from '@mui/material/Button';
-import DeleteIcon from '@mui/icons-material/Delete';
 import {DeviceName} from '../../../../shared/proto';
 import {EditableDeviceDisplayName} from './editableDeviceDisplayName';
-import IconButton from '@mui/material/IconButton';
 import {InventoryItem} from '../../../../proto_out/lightning_vend/model';
+import {InventoryItemCard} from './inventoryItemCard';
 import {InventoryItemDialog} from './inventoryItemDialog';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
@@ -38,44 +37,24 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
       <div>
         <Typography variant={'h4'}>Inventory</Typography>
         {props.adminDeviceView.device.inventory.map((inventoryItem) => (
-          <Paper
-            elevation={6}
-            style={{padding: '10px', margin: '10px 0'}}
-          >
-            <div style={{display: 'inline-block'}}>
-              <Typography variant='h5'>{inventoryItem.displayName}</Typography>
-              <Typography>Price: {inventoryItem.priceSats} sats</Typography>
-              {inventoryItem.vendNullExecutionCommand && (
-                <Typography>
-                  Vend Execution Command: {
-                    inventoryItem.vendNullExecutionCommand
-                  }
-                </Typography>
-              )}
-              {inventoryItem.inventoryCheckBoolExecutionCommand && (
-                <Typography>
-                  Inventory Check Command: {
-                    inventoryItem.inventoryCheckBoolExecutionCommand
-                  }
-                </Typography>
-              )}
-            </div>
-            <IconButton style={{float: 'right'}} onClick={() => {
-              const deviceName =
-                DeviceName.parse(props.adminDeviceView.device.name);
-              // TODO - Indicate to the user if `deviceName` is undefined.
-              if (deviceName) {
-                adminApi.updateDeviceInventory(
-                  deviceName,
-                  props.adminDeviceView.device.inventory.filter(
-                    (i) => i !== inventoryItem
-                  )
-                );
+          <InventoryItemCard
+            inventoryItem={inventoryItem}
+            onDelete={
+              () => {
+                const deviceName =
+                  DeviceName.parse(props.adminDeviceView.device.name);
+                // TODO - Indicate to the user if `deviceName` is undefined.
+                if (deviceName) {
+                  adminApi.updateDeviceInventory(
+                    deviceName,
+                    props.adminDeviceView.device.inventory.filter(
+                      (i) => i !== inventoryItem
+                    )
+                  );
+                }
               }
-            }}>
-              <DeleteIcon/>
-            </IconButton>
-          </Paper>
+            }
+          />
         ))}
         <Button onClick={() => setShowAddInventoryItemDialog(true)}>
           Add Item

--- a/client/src/adminPage/deviceSettingsPanel/index.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/index.tsx
@@ -1,23 +1,17 @@
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {AdminDeviceView} from '../../../../shared/adminSocketTypes';
-import Autocomplete from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import DeleteIcon from '@mui/icons-material/Delete';
 import {DeviceName} from '../../../../shared/proto';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogTitle from '@mui/material/DialogTitle';
 import EditIcon from '@mui/icons-material/Edit';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import {InventoryItem} from '../../../../proto_out/lightning_vend/model';
+import {InventoryItemDialog} from './inventoryItemDialog';
 import OutlinedInput from '@mui/material/OutlinedInput';
 import Paper from '@mui/material/Paper';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import {adminApi} from '../../api/adminApi';
 
@@ -161,88 +155,23 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
         <Button onClick={() => setShowAddInventoryItemDialog(true)}>
           Add Item
         </Button>
-        <Dialog
+        <InventoryItemDialog
           open={showAddInventoryItemDialog}
           onClose={() => setShowAddInventoryItemDialog(false)}
-        >
-          <DialogTitle>
-            Add Inventory Item
-          </DialogTitle>
-          <DialogContent>
-            <DialogContentText>
-              Item will be immediately accessible on the device's UI.
-            </DialogContentText>
-            <TextField
-              style={{display: 'flex', marginTop: '15px'}}
-              label={'Name'}
-              value={newInventoryItem.displayName}
-              onChange={
-                (e) => setNewInventoryItem({
-                  ...newInventoryItem,
-                  displayName: e.target.value
-                })
-              }
-            />
-            <TextField
-              style={{display: 'flex', marginTop: '15px'}}
-              label={'Price (Sats)'}
-              type={'number'}
-              value={`${newInventoryItem.priceSats}`}
-              onChange={
-                (e) => setNewInventoryItem({
-                  ...newInventoryItem,
-                  priceSats: Math.max(Math.floor(Number(e.target.value)), 1)
-                })
-              }
-            />
-            <Autocomplete
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  style={{display: 'flex', marginTop: '15px'}}
-                  label={'Vend Execution Command'}
-                />
-              )}
-              options={props.adminDeviceView.device.nullExecutionCommands}
-              onChange={
-                (e, selectedCommand) => setNewInventoryItem({
-                  ...newInventoryItem,
-                  vendNullExecutionCommand: selectedCommand || ''
-                })
-              }
-              value={newInventoryItem.vendNullExecutionCommand}
-            />
-            <Autocomplete
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  style={{display: 'flex', marginTop: '15px'}}
-                  label={'Inventory Check Command'}
-                />
-              )}
-              options={props.adminDeviceView.device.boolExecutionCommands}
-              onChange={
-                (e, selectedCommand) => setNewInventoryItem({
-                  ...newInventoryItem,
-                  inventoryCheckBoolExecutionCommand: selectedCommand || ''
-                })
-              }
-              value={newInventoryItem.inventoryCheckBoolExecutionCommand}
-            />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setShowAddInventoryItemDialog(false)}>
-              Cancel
-            </Button>
-            <Button onClick={() => {
-              // TODO - Show a loading spinner until this promise resolves
-              // below.
-
+          inventoryItem={newInventoryItem}
+          setInventoryItem={setNewInventoryItem}
+          titleText={'Add Inventory Item'}
+          contentText={
+            'Item will be immediately accessible on the device\'s UI.'
+          }
+          submitText={'Add Item'}
+          onSubmit={
+            () => {
               const deviceName =
                 DeviceName.parse(props.adminDeviceView.device.name);
               // TODO - Indicate to the user if `deviceName` is undefined.
               if (deviceName) {
-                adminApi
+                return adminApi
                   .updateDeviceInventory(
                     deviceName,
                     [
@@ -255,11 +184,10 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
                     setShowAddInventoryItemDialog(false);
                   });
               }
-            }}>
-              Add
-            </Button>
-          </DialogActions>
-        </Dialog>
+            }
+          }
+          device={props.adminDeviceView.device}
+        />
       </div>
     </Paper>
   );

--- a/client/src/adminPage/deviceSettingsPanel/index.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/index.tsx
@@ -39,9 +39,27 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
       <EditableDeviceDisplayName device={props.device}/>
       <Typography variant={'h4'}>Inventory</Typography>
       <div>
-        {props.device.inventory.map((inventoryItem) => (
+        {props.device.inventory.map((inventoryItem, i) => (
           <InventoryItemCard
             inventoryItem={inventoryItem}
+            onUpdate={
+              (updatedInventoryItem) => {
+                const deviceName =
+                  DeviceName.parse(props.device.name);
+                // TODO - Indicate to the user if `deviceName` is undefined.
+                if (deviceName) {
+                  const newInventory = [...props.device.inventory];
+                  newInventory[i] = updatedInventoryItem;
+
+                  return adminApi.updateDeviceInventory(
+                    deviceName,
+                    newInventory
+                  );
+                }
+
+                return Promise.resolve();
+              }
+            }
             onDelete={
               () => {
                 const deviceName =
@@ -57,6 +75,7 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
                 }
               }
             }
+            device={props.device}
           />
         ))}
       </div>

--- a/client/src/adminPage/deviceSettingsPanel/index.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/index.tsx
@@ -2,15 +2,12 @@ import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {AdminDeviceView} from '../../../../shared/adminSocketTypes';
 import Button from '@mui/material/Button';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import DeleteIcon from '@mui/icons-material/Delete';
 import {DeviceName} from '../../../../shared/proto';
-import EditIcon from '@mui/icons-material/Edit';
+import {EditableDeviceDisplayName} from './editableDeviceDisplayName';
 import IconButton from '@mui/material/IconButton';
-import InputAdornment from '@mui/material/InputAdornment';
 import {InventoryItem} from '../../../../proto_out/lightning_vend/model';
 import {InventoryItemDialog} from './inventoryItemDialog';
-import OutlinedInput from '@mui/material/OutlinedInput';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import {adminApi} from '../../api/adminApi';
@@ -22,9 +19,6 @@ interface DeviceSettingsPanelProps {
 const emptyInventoryItem = InventoryItem.create({priceSats: 1});
 
 export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
-  const [isEditingDisplayName, setIsEditingDisplayName] = useState(false);
-  const [newDisplayName, setNewDisplayName] = useState('');
-
   const [
     showAddInventoryItemDialog,
     setShowAddInventoryItemDialog
@@ -34,82 +28,13 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
     setNewInventoryItem
   ] = useState<InventoryItem>(emptyInventoryItem);
 
-  const updateDisplayName = () => {
-    if (props.adminDeviceView) {
-      const deviceName = DeviceName.parse(props.adminDeviceView.device.name);
-      // TODO - Indicate to the user if `deviceName` is undefined.
-      if (deviceName) {
-        adminApi
-          .updateDeviceDisplayName(deviceName, newDisplayName)
-          .then(() => setIsEditingDisplayName(false));
-      }
-    }
-  };
-
-  useEffect(() => {
-    setNewDisplayName(props.adminDeviceView.device.displayName || '');
-  }, [isEditingDisplayName]);
-
   useEffect(() => {
     setNewInventoryItem(emptyInventoryItem);
   }, [showAddInventoryItemDialog]);
 
   return (
     <Paper style={{padding: '10px'}}>
-      {isEditingDisplayName ? (
-          <OutlinedInput
-            // These styles are to match the Typography h2 below.
-            style={{
-              fontWeight: 300,
-              fontSize: '3.75em',
-              lineHeight: 1.2,
-              letterSpacing: '-0.00833em',
-              width: '100%'
-            }}
-            autoFocus
-            value={newDisplayName}
-            onChange={(e) => setNewDisplayName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                updateDisplayName();
-              }
-            }}
-            endAdornment={
-              <InputAdornment position={'end'}>
-                <IconButton
-                  size={'large'}
-                  color={'primary'}
-                  onClick={() => updateDisplayName()}
-                >
-                  <CheckCircleIcon/>
-                </IconButton>
-              </InputAdornment>
-            }
-          />
-        ) : (
-          <div style={{display: 'flex'}}>
-            <Typography
-              variant={'h2'}
-              style={{
-                padding: '23.5px 14px 23.75px',
-                width: '100%',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis'
-              }}
-            >
-              {props.adminDeviceView.device.displayName}
-            </Typography>
-            <IconButton
-              size={'large'}
-              style={{marginTop: '35px', marginRight: '14px', height: '100%'}}
-              onClick={() => setIsEditingDisplayName(!isEditingDisplayName)}
-            >
-              <EditIcon/>
-            </IconButton>
-          </div>
-        )
-      }
+      <EditableDeviceDisplayName device={props.adminDeviceView.device}/>
       <div>
         <Typography variant={'h4'}>Inventory</Typography>
         {props.adminDeviceView.device.inventory.map((inventoryItem) => (

--- a/client/src/adminPage/deviceSettingsPanel/index.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/index.tsx
@@ -66,13 +66,15 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
                   DeviceName.parse(props.device.name);
                 // TODO - Indicate to the user if `deviceName` is undefined.
                 if (deviceName) {
-                  adminApi.updateDeviceInventory(
+                  return adminApi.updateDeviceInventory(
                     deviceName,
                     props.device.inventory.filter(
                       (i) => i !== inventoryItem
                     )
                   );
                 }
+
+                return Promise.resolve();
               }
             }
             device={props.device}

--- a/client/src/adminPage/deviceSettingsPanel/index.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/index.tsx
@@ -124,7 +124,7 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
             style={{padding: '10px', margin: '10px 0'}}
           >
             <div style={{display: 'inline-block'}}>
-              <Typography>Item Name: {inventoryItem.displayName}</Typography>
+              <Typography variant='h5'>{inventoryItem.displayName}</Typography>
               <Typography>Price: {inventoryItem.priceSats} sats</Typography>
               {inventoryItem.vendNullExecutionCommand && (
                 <Typography>

--- a/client/src/adminPage/deviceSettingsPanel/index.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/index.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import {useEffect, useState} from 'react';
-import {AdminDeviceView} from '../../../shared/adminSocketTypes';
+import {AdminDeviceView} from '../../../../shared/adminSocketTypes';
 import Autocomplete from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import DeleteIcon from '@mui/icons-material/Delete';
-import {DeviceName} from '../../../shared/proto';
+import {DeviceName} from '../../../../shared/proto';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -14,12 +14,12 @@ import DialogTitle from '@mui/material/DialogTitle';
 import EditIcon from '@mui/icons-material/Edit';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
-import {InventoryItem} from '../../../proto_out/lightning_vend/model';
+import {InventoryItem} from '../../../../proto_out/lightning_vend/model';
 import OutlinedInput from '@mui/material/OutlinedInput';
 import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import {adminApi} from '../api/adminApi';
+import {adminApi} from '../../api/adminApi';
 
 interface DeviceSettingsPanelProps {
   adminDeviceView: AdminDeviceView

--- a/client/src/adminPage/deviceSettingsPanel/index.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/index.tsx
@@ -126,14 +126,20 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
             <div style={{display: 'inline-block'}}>
               <Typography>Item Name: {inventoryItem.displayName}</Typography>
               <Typography>Price: {inventoryItem.priceSats} sats</Typography>
-              <Typography>
-                Vend Execution Command: {inventoryItem.vendNullExecutionCommand}
-              </Typography>
-              <Typography>
-                Inventory Check Command: {
-                  inventoryItem.inventoryCheckBoolExecutionCommand
-                }
-              </Typography>
+              {inventoryItem.vendNullExecutionCommand && (
+                <Typography>
+                  Vend Execution Command: {
+                    inventoryItem.vendNullExecutionCommand
+                  }
+                </Typography>
+              )}
+              {inventoryItem.inventoryCheckBoolExecutionCommand && (
+                <Typography>
+                  Inventory Check Command: {
+                    inventoryItem.inventoryCheckBoolExecutionCommand
+                  }
+                </Typography>
+              )}
             </div>
             <IconButton style={{float: 'right'}} onClick={() => {
               const deviceName =

--- a/client/src/adminPage/deviceSettingsPanel/index.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/index.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
+import {
+  Device,
+  InventoryItem
+} from '../../../../proto_out/lightning_vend/model';
 import {useEffect, useState} from 'react';
-import {AdminDeviceView} from '../../../../shared/adminSocketTypes';
 import Button from '@mui/material/Button';
 import {DeviceName} from '../../../../shared/proto';
 import {EditableDeviceDisplayName} from './editableDeviceDisplayName';
-import {InventoryItem} from '../../../../proto_out/lightning_vend/model';
 import {InventoryItemCard} from './inventoryItemCard';
 import {InventoryItemDialog} from './inventoryItemDialog';
 import Paper from '@mui/material/Paper';
@@ -12,7 +14,7 @@ import Typography from '@mui/material/Typography';
 import {adminApi} from '../../api/adminApi';
 
 interface DeviceSettingsPanelProps {
-  adminDeviceView: AdminDeviceView
+  device: Device
 }
 
 const emptyInventoryItem = InventoryItem.create({priceSats: 1});
@@ -22,6 +24,7 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
     showAddInventoryItemDialog,
     setShowAddInventoryItemDialog
   ] = useState(false);
+
   const [
     newInventoryItem,
     setNewInventoryItem
@@ -33,21 +36,21 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
 
   return (
     <Paper style={{padding: '10px'}}>
-      <EditableDeviceDisplayName device={props.adminDeviceView.device}/>
+      <EditableDeviceDisplayName device={props.device}/>
       <Typography variant={'h4'}>Inventory</Typography>
       <div>
-        {props.adminDeviceView.device.inventory.map((inventoryItem) => (
+        {props.device.inventory.map((inventoryItem) => (
           <InventoryItemCard
             inventoryItem={inventoryItem}
             onDelete={
               () => {
                 const deviceName =
-                  DeviceName.parse(props.adminDeviceView.device.name);
+                  DeviceName.parse(props.device.name);
                 // TODO - Indicate to the user if `deviceName` is undefined.
                 if (deviceName) {
                   adminApi.updateDeviceInventory(
                     deviceName,
-                    props.adminDeviceView.device.inventory.filter(
+                    props.device.inventory.filter(
                       (i) => i !== inventoryItem
                     )
                   );
@@ -73,14 +76,14 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
         onSubmit={
           () => {
             const deviceName =
-              DeviceName.parse(props.adminDeviceView.device.name);
+              DeviceName.parse(props.device.name);
             // TODO - Indicate to the user if `deviceName` is undefined.
             if (deviceName) {
               return adminApi
                 .updateDeviceInventory(
                   deviceName,
                   [
-                    ...props.adminDeviceView.device.inventory,
+                    ...props.device.inventory,
                     newInventoryItem
                   ]
                 )
@@ -91,7 +94,7 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
             }
           }
         }
-        device={props.adminDeviceView.device}
+        device={props.device}
       />
     </Paper>
   );

--- a/client/src/adminPage/deviceSettingsPanel/index.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/index.tsx
@@ -34,8 +34,8 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
   return (
     <Paper style={{padding: '10px'}}>
       <EditableDeviceDisplayName device={props.adminDeviceView.device}/>
+      <Typography variant={'h4'}>Inventory</Typography>
       <div>
-        <Typography variant={'h4'}>Inventory</Typography>
         {props.adminDeviceView.device.inventory.map((inventoryItem) => (
           <InventoryItemCard
             inventoryItem={inventoryItem}
@@ -56,43 +56,43 @@ export const DeviceSettingsPanel = (props: DeviceSettingsPanelProps) => {
             }
           />
         ))}
-        <Button onClick={() => setShowAddInventoryItemDialog(true)}>
-          Add Item
-        </Button>
-        <InventoryItemDialog
-          open={showAddInventoryItemDialog}
-          onClose={() => setShowAddInventoryItemDialog(false)}
-          inventoryItem={newInventoryItem}
-          setInventoryItem={setNewInventoryItem}
-          titleText={'Add Inventory Item'}
-          contentText={
-            'Item will be immediately accessible on the device\'s UI.'
-          }
-          submitText={'Add Item'}
-          onSubmit={
-            () => {
-              const deviceName =
-                DeviceName.parse(props.adminDeviceView.device.name);
-              // TODO - Indicate to the user if `deviceName` is undefined.
-              if (deviceName) {
-                return adminApi
-                  .updateDeviceInventory(
-                    deviceName,
-                    [
-                      ...props.adminDeviceView.device.inventory,
-                      newInventoryItem
-                    ]
-                  )
-                  .then(() => {
-                    setNewInventoryItem(emptyInventoryItem);
-                    setShowAddInventoryItemDialog(false);
-                  });
-              }
+      </div>
+      <Button onClick={() => setShowAddInventoryItemDialog(true)}>
+        Add Item
+      </Button>
+      <InventoryItemDialog
+        open={showAddInventoryItemDialog}
+        onClose={() => setShowAddInventoryItemDialog(false)}
+        inventoryItem={newInventoryItem}
+        setInventoryItem={setNewInventoryItem}
+        titleText={'Add Inventory Item'}
+        contentText={
+          'Item will be immediately accessible on the device\'s UI.'
+        }
+        submitText={'Add Item'}
+        onSubmit={
+          () => {
+            const deviceName =
+              DeviceName.parse(props.adminDeviceView.device.name);
+            // TODO - Indicate to the user if `deviceName` is undefined.
+            if (deviceName) {
+              return adminApi
+                .updateDeviceInventory(
+                  deviceName,
+                  [
+                    ...props.adminDeviceView.device.inventory,
+                    newInventoryItem
+                  ]
+                )
+                .then(() => {
+                  setNewInventoryItem(emptyInventoryItem);
+                  setShowAddInventoryItemDialog(false);
+                });
             }
           }
-          device={props.adminDeviceView.device}
-        />
-      </div>
+        }
+        device={props.adminDeviceView.device}
+      />
     </Paper>
   );
 };

--- a/client/src/adminPage/deviceSettingsPanel/inventoryItemCard.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/inventoryItemCard.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import DeleteIcon from '@mui/icons-material/Delete';
+import IconButton from '@mui/material/IconButton';
+import {InventoryItem} from '../../../../proto_out/lightning_vend/model';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+
+interface InventoryItemCardProps {
+  inventoryItem: InventoryItem,
+  onDelete: () => void
+}
+
+export const InventoryItemCard = (props: InventoryItemCardProps) => {
+  return (
+    <Paper
+      elevation={6}
+      style={{padding: '10px', margin: '10px 0'}}
+    >
+      <div style={{display: 'inline-block'}}>
+        <Typography variant='h5'>{props.inventoryItem.displayName}</Typography>
+        <Typography>Price: {props.inventoryItem.priceSats} sats</Typography>
+        {props.inventoryItem.vendNullExecutionCommand && (
+          <Typography>
+            Vend Execution Command: {
+              props.inventoryItem.vendNullExecutionCommand
+            }
+          </Typography>
+        )}
+        {props.inventoryItem.inventoryCheckBoolExecutionCommand && (
+          <Typography>
+            Inventory Check Command: {
+              props.inventoryItem.inventoryCheckBoolExecutionCommand
+            }
+          </Typography>
+        )}
+      </div>
+      <IconButton style={{float: 'right'}} onClick={props.onDelete}>
+        <DeleteIcon/>
+      </IconButton>
+    </Paper>
+  );
+};

--- a/client/src/adminPage/deviceSettingsPanel/inventoryItemCard.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/inventoryItemCard.tsx
@@ -1,16 +1,38 @@
 import * as React from 'react';
+import {
+  Device,
+  InventoryItem
+} from '../../../../proto_out/lightning_vend/model';
+import {useEffect, useState} from 'react';
 import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
 import IconButton from '@mui/material/IconButton';
-import {InventoryItem} from '../../../../proto_out/lightning_vend/model';
+import {InventoryItemDialog} from './inventoryItemDialog';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 
 interface InventoryItemCardProps {
   inventoryItem: InventoryItem,
-  onDelete: () => void
+  onUpdate: (inventoryItem: InventoryItem) => Promise<void>,
+  onDelete: () => void,
+  device: Device
 }
 
 export const InventoryItemCard = (props: InventoryItemCardProps) => {
+  const [
+    showUpdateInventoryItemDialog,
+    setShowUpdateInventoryItemDialog
+  ] = useState(false);
+
+  const [
+    updatedInventoryItem,
+    setUpdatedInventoryItem
+  ] = useState(props.inventoryItem);
+
+  useEffect(() => {
+    setUpdatedInventoryItem(props.inventoryItem);
+  }, [props.inventoryItem, showUpdateInventoryItemDialog]);
+
   return (
     <Paper
       elevation={6}
@@ -34,9 +56,35 @@ export const InventoryItemCard = (props: InventoryItemCardProps) => {
           </Typography>
         )}
       </div>
-      <IconButton style={{float: 'right'}} onClick={props.onDelete}>
-        <DeleteIcon/>
-      </IconButton>
+      <div style={{float: 'right'}}>
+        <IconButton onClick={() => setShowUpdateInventoryItemDialog(true)}>
+          <EditIcon/>
+        </IconButton>
+        <IconButton onClick={props.onDelete}>
+          <DeleteIcon/>
+        </IconButton>
+      </div>
+      <InventoryItemDialog
+        open={showUpdateInventoryItemDialog}
+        onClose={() => setShowUpdateInventoryItemDialog(false)}
+        inventoryItem={updatedInventoryItem}
+        setInventoryItem={setUpdatedInventoryItem}
+        titleText={'Edit Inventory Item'}
+        contentText={
+          'Item will be immediately accessible on the device\'s UI.'
+        }
+        submitText={'Save Changes'}
+        onSubmit={
+          () => {
+            return props.onUpdate(updatedInventoryItem)
+              .then(() => {
+                setUpdatedInventoryItem(props.inventoryItem);
+                setShowUpdateInventoryItemDialog(false);
+              });
+          }
+        }
+        device={props.device}
+      />
     </Paper>
   );
 };

--- a/client/src/adminPage/deviceSettingsPanel/inventoryItemCard.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/inventoryItemCard.tsx
@@ -8,6 +8,9 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import IconButton from '@mui/material/IconButton';
 import {InventoryItemDialog} from './inventoryItemDialog';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 
@@ -33,6 +36,11 @@ export const InventoryItemCard = (props: InventoryItemCardProps) => {
     setUpdatedInventoryItem(props.inventoryItem);
   }, [props.inventoryItem, showUpdateInventoryItemDialog]);
 
+  const [
+    menuAnchorEl,
+    setMenuAnchorEl
+  ] = React.useState<null | HTMLElement>(null);
+
   return (
     <Paper
       elevation={6}
@@ -57,12 +65,29 @@ export const InventoryItemCard = (props: InventoryItemCardProps) => {
         )}
       </div>
       <div style={{float: 'right'}}>
-        <IconButton onClick={() => setShowUpdateInventoryItemDialog(true)}>
-          <EditIcon/>
+        <IconButton onClick={(event) => setMenuAnchorEl(event.currentTarget)}>
+          <MoreVertIcon/>
         </IconButton>
-        <IconButton onClick={props.onDelete}>
-          <DeleteIcon/>
-        </IconButton>
+        <Menu
+          anchorEl={menuAnchorEl}
+          open={Boolean(menuAnchorEl)}
+          onClose={() => setMenuAnchorEl(null)}
+        >
+          <MenuItem onClick={() => {
+            setMenuAnchorEl(null);
+            setShowUpdateInventoryItemDialog(true);
+          }}>
+            <EditIcon style={{paddingRight: '10px'}}/>
+            Edit
+          </MenuItem>
+          <MenuItem onClick={() => {
+            setMenuAnchorEl(null);
+            props.onDelete();
+          }}>
+            <DeleteIcon style={{paddingRight: '10px'}}/>
+            Delete
+          </MenuItem>
+        </Menu>
       </div>
       <InventoryItemDialog
         open={showUpdateInventoryItemDialog}

--- a/client/src/adminPage/deviceSettingsPanel/inventoryItemCard.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/inventoryItemCard.tsx
@@ -4,10 +4,17 @@ import {
   InventoryItem
 } from '../../../../proto_out/lightning_vend/model';
 import {useEffect, useState} from 'react';
+import Button from '@mui/material/Button';
 import DeleteIcon from '@mui/icons-material/Delete';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
 import EditIcon from '@mui/icons-material/Edit';
 import IconButton from '@mui/material/IconButton';
 import {InventoryItemDialog} from './inventoryItemDialog';
+import LoadingButton from '@mui/lab/LoadingButton';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
@@ -17,7 +24,7 @@ import Typography from '@mui/material/Typography';
 interface InventoryItemCardProps {
   inventoryItem: InventoryItem,
   onUpdate: (inventoryItem: InventoryItem) => Promise<void>,
-  onDelete: () => void,
+  onDelete: () => Promise<void>,
   device: Device
 }
 
@@ -31,6 +38,16 @@ export const InventoryItemCard = (props: InventoryItemCardProps) => {
     updatedInventoryItem,
     setUpdatedInventoryItem
   ] = useState(props.inventoryItem);
+
+  const [
+    showDeleteInventoryItemDialog,
+    setShowDeleteInventoryItemDialog
+  ] = useState(false);
+
+  const [
+    isDeleting,
+    setIsDeleting
+  ] = useState(false);
 
   useEffect(() => {
     setUpdatedInventoryItem(props.inventoryItem);
@@ -82,7 +99,7 @@ export const InventoryItemCard = (props: InventoryItemCardProps) => {
           </MenuItem>
           <MenuItem onClick={() => {
             setMenuAnchorEl(null);
-            props.onDelete();
+            setShowDeleteInventoryItemDialog(true);
           }}>
             <DeleteIcon style={{paddingRight: '10px'}}/>
             Delete
@@ -110,6 +127,33 @@ export const InventoryItemCard = (props: InventoryItemCardProps) => {
         }
         device={props.device}
       />
+      <Dialog
+        open={showDeleteInventoryItemDialog}
+        onClose={() => setShowDeleteInventoryItemDialog(false)}
+      >
+        <DialogTitle>
+          Delete Inventory Item
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to delete this inventory item?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowDeleteInventoryItemDialog(false)}>
+            Cancel
+          </Button>
+          <LoadingButton loading={isDeleting} onClick={() => {
+            setIsDeleting(true);
+            props.onDelete().then(() => {
+              setIsDeleting(false);
+              setShowDeleteInventoryItemDialog(false);
+            });
+          }}>
+            Delete
+          </LoadingButton>
+        </DialogActions>
+      </Dialog>
     </Paper>
   );
 };

--- a/client/src/adminPage/deviceSettingsPanel/inventoryItemCard.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/inventoryItemCard.tsx
@@ -96,7 +96,7 @@ export const InventoryItemCard = (props: InventoryItemCardProps) => {
         setInventoryItem={setUpdatedInventoryItem}
         titleText={'Edit Inventory Item'}
         contentText={
-          'Item will be immediately accessible on the device\'s UI.'
+          'Changes will be immediately reflected on the device\'s UI.'
         }
         submitText={'Save Changes'}
         onSubmit={

--- a/client/src/adminPage/deviceSettingsPanel/inventoryItemDialog.tsx
+++ b/client/src/adminPage/deviceSettingsPanel/inventoryItemDialog.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import {
+  Device,
+  InventoryItem
+} from '../../../../proto_out/lightning_vend/model';
+import Autocomplete from '@mui/material/Autocomplete';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import LoadingButton from '@mui/lab/LoadingButton';
+import TextField from '@mui/material/TextField';
+import {useState} from 'react';
+
+interface InventoryItemDialogProps {
+  open: boolean,
+  onClose: () => void,
+  inventoryItem: InventoryItem,
+  setInventoryItem: (inventoryItem: InventoryItem) => void,
+  titleText: string,
+  contentText: string,
+  submitText: string,
+  /**
+   * Called when the dialog box is submitted by the user. The dialog closes
+   * itself after this function is called. If this function returns a promise,
+   * the dialog will wait for the promise to resolve before closing. Otherwise,
+   * the dialog will close immediately.
+   * @returns Nothing if the dialog submission is synchronous, or an empty
+   * promise if the dialog submission is asynchronous.
+   */
+  onSubmit: () => void | Promise<void>,
+  device: Device
+}
+
+export const InventoryItemDialog = (props: InventoryItemDialogProps) => {
+  const [submitting, setSubmitting] = useState(false);
+
+  return (
+    <Dialog
+      open={props.open}
+      onClose={props.onClose}
+    >
+      <DialogTitle>
+        {props.titleText}
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          {props.contentText}
+        </DialogContentText>
+        <TextField
+          style={{display: 'flex', marginTop: '15px'}}
+          label={'Name'}
+          value={props.inventoryItem.displayName}
+          onChange={
+            (e) => props.setInventoryItem({
+              ...props.inventoryItem,
+              displayName: e.target.value
+            })
+          }
+        />
+        <TextField
+          style={{display: 'flex', marginTop: '15px'}}
+          label={'Price (Sats)'}
+          type={'number'}
+          value={`${props.inventoryItem.priceSats}`}
+          onChange={
+            (e) => props.setInventoryItem({
+              ...props.inventoryItem,
+              priceSats: Math.max(Math.floor(Number(e.target.value)), 1)
+            })
+          }
+        />
+        <Autocomplete
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              style={{display: 'flex', marginTop: '15px'}}
+              label={'Vend Execution Command'}
+            />
+          )}
+          options={props.device.nullExecutionCommands}
+          onChange={
+            (e, selectedCommand) => props.setInventoryItem({
+              ...props.inventoryItem,
+              vendNullExecutionCommand: selectedCommand || ''
+            })
+          }
+          value={props.inventoryItem.vendNullExecutionCommand}
+        />
+        <Autocomplete
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              style={{display: 'flex', marginTop: '15px'}}
+              label={'Inventory Check Command'}
+            />
+          )}
+          options={props.device.boolExecutionCommands}
+          onChange={
+            (e, selectedCommand) => props.setInventoryItem({
+              ...props.inventoryItem,
+              inventoryCheckBoolExecutionCommand: selectedCommand || ''
+            })
+          }
+          value={props.inventoryItem.inventoryCheckBoolExecutionCommand}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.onClose}>
+          Cancel
+        </Button>
+        <LoadingButton loading={submitting} onClick={() => {
+          const submitResponse = props.onSubmit();
+
+          // If `submitResponse` is a asynchronous, wait for it to resolve
+          // before closing the dialog. Otherwise, just close the dialog.
+          if (submitResponse instanceof Promise) {
+            setSubmitting(true);
+            submitResponse.then(() => {
+              setSubmitting(false);
+              props.onClose();
+            });
+          } else {
+            props.onClose();
+          }
+        }}>
+          {props.submitText}
+        </LoadingButton>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -13,7 +13,7 @@ export default (
   _: any,
   {watch, mode}: {watch?: boolean, mode?: string}
 ): webpack.Configuration => {
-  const maxBundleSize = mode === 'production' ? 790000 : 4300000;
+  const maxBundleSize = mode === 'production' ? 800000 : 4300000;
 
   return {
     entry: `${SRC_DIR}/index.tsx`,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -13,7 +13,7 @@ export default (
   _: any,
   {watch, mode}: {watch?: boolean, mode?: string}
 ): webpack.Configuration => {
-  const maxBundleSize = mode === 'production' ? 790000 : 4200000;
+  const maxBundleSize = mode === 'production' ? 790000 : 4300000;
 
   return {
     entry: `${SRC_DIR}/index.tsx`,


### PR DESCRIPTION
Move `DeviceSettingsPanel` component into its own directory and split it up into multiple sub-components. Also clean things up along the way, allow for better code reuse, and add features such as inventory editing and showing loading spinners to the user where appropriate.

Fixes #30