### PR TITLE
Device claiming FAB is always at the very bottom

### DIFF
--- a/frontend/client/src/adminPage.tsx
+++ b/frontend/client/src/adminPage.tsx
@@ -107,10 +107,10 @@ export const AdminPage = () => {
         <div>
           <Fab
             color={'primary'}
-            style={{position: 'absolute', bottom: '20px', right: '20px'}}
+            style={{position: 'fixed', bottom: '20px', right: '20px'}}
             onClick={() => setShowClaimDeviceDialog(true)}
           >
-            <AddIcon />
+            <AddIcon/>
           </Fab>
           <Dialog
             onClose={() => setShowClaimDeviceDialog(false)}


### PR DESCRIPTION
Previously the FAB used CSS absolute positioning, which meant that it was in the correct position _only_ if the user didn't scroll down. Now it properly handles user scrolling.