### PR TITLE
Fix command executor server

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -41,5 +41,4 @@ jobs:
         cargo check
         cargo fmt -- --check
         cargo clippy -- -D warnings
-        sh build_for_pi.sh
         cd ..

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -41,7 +41,6 @@ jobs:
         cargo check
         cargo fmt -- --check
         cargo clippy -- -D warnings
-        sh build_for_pi.sh
         cd ..
   deploy:
     needs: test

--- a/command_executor_server/.cargo/config.toml
+++ b/command_executor_server/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"

--- a/command_executor_server/Cargo.lock
+++ b/command_executor_server/Cargo.lock
@@ -592,6 +592,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "libudev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
+dependencies = [
+ "libc",
+ "libudev-sys",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +851,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "powerfmt"
@@ -1183,6 +1209,7 @@ dependencies = [
  "IOKit-sys",
  "bitflags 2.0.2",
  "cfg-if",
+ "libudev",
  "mach2",
  "nix",
  "regex",

--- a/command_executor_server/Cargo.lock
+++ b/command_executor_server/Cargo.lock
@@ -320,9 +320,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -344,33 +344,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -507,7 +507,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi",
@@ -1123,9 +1123,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.26"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f3f8f960ed3b5a59055428714943298bf3fa2d4a1d53135084e0544829d995"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -1161,18 +1161,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1192,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -1252,9 +1252,9 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1371,7 +1371,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys",
 ]
@@ -1400,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "8ff9e3abce27ee2c9a37f9ad37238c1bdd4e789c84ba37df76aa4d528f5072cc"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1426,18 +1426,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.0.2",
  "serde",
@@ -1486,12 +1486,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 

--- a/command_executor_server/Cargo.toml
+++ b/command_executor_server/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 rayon = "1.8.0"
 rocket = { version = "0.5.0-rc.3", features = ["json"] }
-serde = { version = "1.0.189", features = ["derive"] }
+serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.107"
 serialport = "4.2.2"

--- a/command_executor_server/Cargo.toml
+++ b/command_executor_server/Cargo.toml
@@ -8,4 +8,4 @@ rayon = "1.8.0"
 rocket = { version = "0.5.0-rc.3", features = ["json"] }
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
-serialport = { version = "4.2.2", default-features = false }
+serialport = "4.2.2"

--- a/command_executor_server/build_for_pi.sh
+++ b/command_executor_server/build_for_pi.sh
@@ -1,4 +1,0 @@
-sudo apt-get update
-sudo apt-get install -y gcc-arm-linux-gnueabihf
-rustup target add armv7-unknown-linux-gnueabihf
-cargo build --release --target=armv7-unknown-linux-gnueabihf

--- a/command_executor_server/src/main.rs
+++ b/command_executor_server/src/main.rs
@@ -95,8 +95,24 @@ impl Fairing for Cors {
 #[rocket::launch]
 async fn rocket() -> _ {
     println!("Bootstrapping Arduino(s)...");
-    let liveace_serial_ports: Vec<LiVeAceSerialPort> = serialport::available_ports()
-        .unwrap_or_default()
+    let serial_ports = match serialport::available_ports() {
+        Ok(serial_ports) => {
+            println!("Discovered {} serial ports", serial_ports.len());
+            println!();
+            for serial_port in &serial_ports {
+                println!("{:#?}", serial_port);
+                println!();
+            }
+            serial_ports
+        }
+        Err(err) => {
+            println!("Unable to enumerate serial ports: {}", err);
+            Vec::default()
+        }
+    };
+
+    println!("Discovering LiVeACE Arduinos...");
+    let liveace_serial_ports: Vec<LiVeAceSerialPort> = serial_ports
         .into_par_iter()
         .map(get_liveace_serial_port)
         .filter_map(|port_or| port_or)

--- a/command_executor_server/src/main.rs
+++ b/command_executor_server/src/main.rs
@@ -17,13 +17,12 @@ use std::sync::Mutex;
 fn run_null_command_handler(
     command: String,
     command_executor_manager_mutex: &State<Mutex<CommandExecutorManager>>,
-) -> Result<rocket::serde::json::Json<String>, rocket::response::status::NotFound<String>> {
+) -> Result<rocket::serde::json::Json<serde_json::Value>, rocket::response::status::NotFound<String>>
+{
     let mut command_executor_manager = command_executor_manager_mutex.lock().unwrap();
 
     match command_executor_manager.execute_null_command(&command) {
-        Ok(_) => Ok(rocket::serde::json::Json(
-            serde_json::json!(null).to_string(),
-        )),
+        Ok(_) => Ok(rocket::serde::json::Json(serde_json::json!(null))),
         Err(err) => {
             // TODO - NotFound isn't always going to be the right response here. Let's take more care to make sure we always return a relevant HTTP status code.
             Err(rocket::response::status::NotFound(format!("{err:?}")))
@@ -35,13 +34,12 @@ fn run_null_command_handler(
 fn run_bool_command_handler(
     command: String,
     command_executor_manager_mutex: &State<Mutex<CommandExecutorManager>>,
-) -> Result<rocket::serde::json::Json<String>, rocket::response::status::NotFound<String>> {
+) -> Result<rocket::serde::json::Json<serde_json::Value>, rocket::response::status::NotFound<String>>
+{
     let mut command_executor_manager = command_executor_manager_mutex.lock().unwrap();
 
     match command_executor_manager.execute_bool_command(&command) {
-        Ok(bool_res) => Ok(rocket::serde::json::Json(
-            serde_json::json!(bool_res).to_string(),
-        )),
+        Ok(bool_res) => Ok(rocket::serde::json::Json(serde_json::json!(bool_res))),
         Err(err) => {
             // TODO - NotFound isn't always going to be the right response here. Let's take more care to make sure we always return a relevant HTTP status code.
             Err(rocket::response::status::NotFound(format!("{err:?}")))
@@ -52,7 +50,7 @@ fn run_bool_command_handler(
 #[get("/listCommands")]
 fn list_commands_handler(
     command_executor_manager_mutex: &State<Mutex<CommandExecutorManager>>,
-) -> rocket::serde::json::Json<String> {
+) -> rocket::serde::json::Json<serde_json::Value> {
     let command_executor_manager = command_executor_manager_mutex.lock().unwrap();
 
     let mut null_commands: Vec<&str> = command_executor_manager.get_null_commands().collect();
@@ -61,13 +59,10 @@ fn list_commands_handler(
     let mut bool_commands: Vec<&str> = command_executor_manager.get_bool_commands().collect();
     bool_commands.sort();
 
-    rocket::serde::json::Json(
-        serde_json::json!({
-            "nullCommands": null_commands,
-            "boolCommands": bool_commands
-        })
-        .to_string(),
-    )
+    rocket::serde::json::Json(serde_json::json!({
+        "nullCommands": null_commands,
+        "boolCommands": bool_commands
+    }))
 }
 
 struct Cors;

--- a/pi_device_setup.sh
+++ b/pi_device_setup.sh
@@ -13,7 +13,7 @@ set -e
 USER=${SUDO_USER:-$USER}
 
 # Install dependencies.
-apt -y install xdotool unclutter
+apt -y install xdotool unclutter libudev-dev
 
 # Install Rust.
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
There were two things wrong with it:

1. HTTP responses were string instead of JSON
2. `libudev` was disabled for the `serialport` crate, which caused Arduino boards to not be recognized on Linux (but still recognized on Windows and MacOS)